### PR TITLE
Create Github Action to automate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:  
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+
+        - name: Create Release
+          uses: softprops/action-gh-release@v1
+          if: startsWith(github.ref, 'refs/tags/')
+          with:
+            tag_name: ${{ github.ref_name }}
+            name: Release ${{ github.ref_name }}
+            draft: true
+            prerelease: false
+            generate_release_notes: true
+  artefact:
+    strategy:
+          matrix:
+            include:
+              - name: Linux x86_64
+                os: ubuntu-latest
+                target: x86_64-unknown-linux-musl
+              - name: macOS x86_64
+                os: macos-latest
+                target: x86_64-apple-darwin
+              - name: macOS M1
+                os: macos-latest
+                target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    name: Create artefact for ${{ matrix.name }}
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: ${{ matrix.target }}
+          toolchain: stable
+      - name: Install musl-tools
+        run: sudo apt update -y && sudo apt install musl-tools -y
+        if: matrix.os == 'ubuntu-latest'
+      - name: Build
+        run: cargo build --target ${{ matrix.target }} --release
+      - name: Move binary
+        run: mv target/${{ matrix.target }}/release/osc-cost osc-cost-${{ github.ref_name }}-${{ matrix.target }}
+      - name: Upload Artefact to release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: true
+          prerelease: false
+          files: osc-cost-${{ github.ref_name }}-${{ matrix.target }}


### PR DESCRIPTION
This PR create a draft release triggered when a tag is pushed and it uploads different binaires for linux, mac and mac M1

See [here](https://github.com/outscale-mdr/osc-cost/actions/runs/3747945431) for a proof

Closes #1
Closes #27